### PR TITLE
Actualización para entrega 2

### DIFF
--- a/t-1.h
+++ b/t-1.h
@@ -303,6 +303,7 @@ void array_force_add2(Array *array, Order *iValueToAdd){
 	}
 	else
 	{
+		int c=1;
 		while(1){
 			hashed_value = universal(hashed_value); //Segundo método de hashing entregado
 			position = hashed_value%array->capacity;
@@ -584,6 +585,7 @@ void array_add2(Array *array, Order *iValueToAdd){
 	}
 	else
 	{
+		int c=1;
 		while(1){
 			hashed_value = universal(hashed_value); //Segundo método de hashing entregado
 			position = hashed_value%array->capacity;

--- a/t-1.h
+++ b/t-1.h
@@ -313,7 +313,8 @@ void array_force_add2(Array *array, Order *iValueToAdd){
 				array->content[position] = iValueToAdd;
 				break;
 			}
-			else
+			c+=1;
+			if (c>=array->capacity)
 			{
 				if (position==hash(iValueToAdd->type)%array->capacity){ 
 					printf("ERROR. The content could not be allocated\n");
@@ -593,7 +594,8 @@ void array_add2(Array *array, Order *iValueToAdd){
 				array->content[position] = iValueToAdd;
 				break;
 			}
-			else
+			c+=1;
+			if (c>=array->capacity)
 			{
 				if (position==hash(iValueToAdd->type)%array->capacity){ 
 					printf("ERROR. The content could not be allocated\n");


### PR DESCRIPTION
Actualización del enano bug que noté gracias a los archivos de ejemplo que fueron subidos después de la fecha de la primera entrega.

El único archivo correcto de la primera entrega funcionaba perfecto sin resolver este bug que lanza error solo en archivos grandes (O en una situación muy particular). Dado que el valor del segundo array podia repetir la poscición sin estar repitiendo el ciclo de posciciones. Se cambia de tal forma que tras n repeticiones se verifique que no estamos repitiendo el lugar inicial.
